### PR TITLE
fix(form-control-mixin): changed value definition to prototype if the super is using prototype

### DIFF
--- a/.changeset/slimy-hornets-explode.md
+++ b/.changeset/slimy-hornets-explode.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/form-control': patch
+---
+
+Fix value lookup

--- a/packages/form-control/src/FormControlMixin.ts
+++ b/packages/form-control/src/FormControlMixin.ts
@@ -226,7 +226,7 @@ export function FormControlMixin<
       const get = descriptor && descriptor.get;
 
       /** Define the FormControl's value property */
-      Object.defineProperty(this, 'value', {
+      Object.defineProperty(this.hasOwnProperty('value') ? this :  this.constructor.prototype, 'value', {
         get() {
           /** If a getter already exists, make sure to call it */
           if (get) {


### PR DESCRIPTION
Fixes an issue where Lit complains about an instance property (via field) in dev mode.﻿
