### PR TITLE
Internal Input validators

### DIFF
--- a/packages/form-control/src/FormControlMixin.ts
+++ b/packages/form-control/src/FormControlMixin.ts
@@ -445,7 +445,7 @@ export function FormControlMixin<
          */
         validity[key] = !valid;
 
-        if (valid === false) {
+        if (valid === false && validationMessage === '') {
           isValid = false;
           let messageResult = '';
 

--- a/packages/form-control/src/types.ts
+++ b/packages/form-control/src/types.ts
@@ -87,4 +87,4 @@ export interface IControlHost {
   disabled?: boolean;
 }
 
-export type DefaultErrorMessages = Partial<Record<keyof ValidityState, string | ((instance: HTMLInputElement) => string)>>;
+export type DefaultErrorMessages = Partial<Record<keyof ValidityState, string | ((instance: HTMLElement & { validationTarget: HTMLInputElement} ) => string)>>;

--- a/packages/form-control/src/types.ts
+++ b/packages/form-control/src/types.ts
@@ -86,3 +86,5 @@ export interface IControlHost {
   checked?: boolean;
   disabled?: boolean;
 }
+
+export type DefaultErrorMessages = Partial<Record<keyof ValidityState, string | ((instance: HTMLInputElement) => string)>>;

--- a/packages/form-control/src/validators.ts
+++ b/packages/form-control/src/validators.ts
@@ -92,13 +92,13 @@ export const internalInputValidators = (defaultErrorMessages: DefaultErrorMessag
   const validityStates: DefaultErrorMessages = {
     valueMissing: () => 'Please fill out this field.',
     badInput: () => 'Please enter a valid value.',
-    tooShort: (validationTarget: HTMLInputElement) => `Please enter at least ${validationTarget.minLength} characters.`,
-    tooLong: (validationTarget: HTMLInputElement) => `Please enter no more than ${validationTarget.maxLength} characters.`,
-    rangeOverflow: (validationTarget: HTMLInputElement) => `Please enter a value less than ${validationTarget.max}.`,
-    rangeUnderflow: (validationTarget: HTMLInputElement) => `Please enter a value greater than ${validationTarget.min}.`,
-    patternMismatch: (validationTarget: HTMLInputElement) => `Please match the requested format: ${validationTarget.pattern}.`,
-    stepMismatch: (validationTarget: HTMLInputElement) => `Please enter a value that is evenly divisible by ${validationTarget.step}.`,
-    typeMismatch: (validationTarget: HTMLInputElement) => `Please enter a value that corresponds to type: ${validationTarget.type}`,
+    tooShort: ({validationTarget}) => `Please enter at least ${validationTarget.minLength} characters.`,
+    tooLong: ({validationTarget}) => `Please enter no more than ${validationTarget.maxLength} characters.`,
+    rangeOverflow: ({validationTarget}) => `Please enter a value less than ${validationTarget.max}.`,
+    rangeUnderflow: ({validationTarget}) => `Please enter a value greater than ${validationTarget.min}.`,
+    patternMismatch: ({validationTarget}) => `Please match the requested format: ${validationTarget.pattern}.`,
+    stepMismatch: ({validationTarget}) => `Please enter a value that is evenly divisible by ${validationTarget.step}.`,
+    typeMismatch: ({validationTarget}) => `Please enter a value that corresponds to type: ${validationTarget.type}`,
   };
 
   return (Object.entries(validityStates) as [keyof ValidityState, Function][]).map(([validityState, ourErrorMessage]): Validator => ({
@@ -106,10 +106,10 @@ export const internalInputValidators = (defaultErrorMessages: DefaultErrorMessag
     message(instance: HTMLElement & { validationTarget: HTMLInputElement}) {
 
       const theirErrorMessage = defaultErrorMessages[validityState] instanceof Function ?
-        (defaultErrorMessages[validityState] as Function)(instance.validationTarget) :
+        (defaultErrorMessages[validityState] as Function)(instance) :
         defaultErrorMessages[validityState];
 
-      return theirErrorMessage || ourErrorMessage(instance.validationTarget);
+      return theirErrorMessage || ourErrorMessage(instance);
     },
     callback(instance: HTMLElement & { validationTarget: HTMLInputElement}) {
       return instance.validationTarget ? !instance.validationTarget.validity[validityState] : true;

--- a/packages/form-control/src/validators.ts
+++ b/packages/form-control/src/validators.ts
@@ -1,5 +1,5 @@
 import { Validator } from './index';
-import { FormControlInterface, FormValue } from './types';
+import { FormControlInterface, FormValue, DefaultErrorMessages } from './types';
 
 export const requiredValidator: Validator = {
   attribute: 'required',
@@ -87,8 +87,6 @@ export const patternValidator: Validator = {
     return !!regExp.exec(value);
   }
 };
-
-type DefaultErrorMessages = Partial<Record<keyof ValidityState, string | ((instance: HTMLInputElement) => string)>>;
 
 export const internalInputValidators = (defaultErrorMessages: DefaultErrorMessages = {}): Validator[] => {
   const validityStates: DefaultErrorMessages = {

--- a/packages/form-control/tests/validators.test.ts
+++ b/packages/form-control/tests/validators.test.ts
@@ -22,7 +22,7 @@ const testDefaultErrorMessages: DefaultErrorMessages = {
   badInput: 'some badInput message',
   tooLong: 'some tooLong message',
   tooShort: 'some tooShort message',
-  rangeOverflow: (target) => `some rangeOverflow message ${target.name}`,
+  rangeOverflow: (instance) => `some rangeOverflow message ${instance.name}`,
   rangeUnderflow: 'some rangeUnderflow message',
   patternMismatch: 'some pattern message',
   stepMismatch: 'some step message',
@@ -437,7 +437,7 @@ describe('Internal Input Validators with custom default error messages', () => {
 
     el.validationTarget.dispatchEvent( new CustomEvent('change'));
 
-    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.valueMissing as any), el.validationTarget));
+    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.valueMissing as any), el));
   });
 
   it('returns badInput validity', async () => {
@@ -450,7 +450,7 @@ describe('Internal Input Validators with custom default error messages', () => {
 
     await elementUpdated(el);
 
-    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.badInput as any), el.validationTarget));
+    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.badInput as any), el));
   });
 
   it('returns typeMismatch validity', async () => {
@@ -463,7 +463,7 @@ describe('Internal Input Validators with custom default error messages', () => {
 
     await elementUpdated(el);
 
-    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.typeMismatch as any), el.validationTarget));
+    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.typeMismatch as any), el));
   });
 
   it('returns tooShort validity', async () => {
@@ -477,7 +477,7 @@ describe('Internal Input Validators with custom default error messages', () => {
 
     await elementUpdated(el);
 
-    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.tooShort as any), el.validationTarget));
+    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.tooShort as any), el));
   });
 
   it('returns tooLong validity', async () => {
@@ -495,7 +495,7 @@ describe('Internal Input Validators with custom default error messages', () => {
 
     await elementUpdated(el);
 
-    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.tooLong as any), el.validationTarget));
+    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.tooLong as any), el));
   });
 
   it('returns rangeOverflow validity', async () => {
@@ -509,7 +509,7 @@ describe('Internal Input Validators with custom default error messages', () => {
 
     await elementUpdated(el);
 
-    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.rangeOverflow as any), el.validationTarget));
+    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.rangeOverflow as any), el));
   });
 
   it('returns rangeUnderflow validity', async () => {
@@ -523,7 +523,7 @@ describe('Internal Input Validators with custom default error messages', () => {
 
     await elementUpdated(el);
 
-    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.rangeUnderflow as any), el.validationTarget));
+    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.rangeUnderflow as any), el));
   });
 
   it('returns stepMismatch validity', async () => {
@@ -537,7 +537,7 @@ describe('Internal Input Validators with custom default error messages', () => {
 
     await elementUpdated(el);
 
-    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.stepMismatch as any), el.validationTarget));
+    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.stepMismatch as any), el));
   });
 
   it('returns patternMismatch validity', async () => {
@@ -549,7 +549,7 @@ describe('Internal Input Validators with custom default error messages', () => {
 
     await elementUpdated(el);
 
-    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.patternMismatch as any), el.validationTarget));
+    expect(el.validationMessage).to.equal(validatorMessage((testDefaultErrorMessages.patternMismatch as any), el));
   });
 
 });


### PR DESCRIPTION
Added a generator function that creates a validator for each ValidityState key that passes the same ValidityState key value from an expected internal input (validationTarget) up to the host element's validity. The generator function also accepts an object of custom error messages to override our defaults.