### PR TITLE
chore: moving form helpers to a module package

### DIFF
--- a/.changeset/rich-llamas-stare.md
+++ b/.changeset/rich-llamas-stare.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/form-helpers': minor
+---
+
+Upgrade helpers to a module package

--- a/packages/form-helpers/package.json
+++ b/packages/form-helpers/package.json
@@ -4,6 +4,7 @@
   "description": "Helpers for working with forms",
   "main": "index.js",
   "module": "index.js",
+  "type": "module",
   "exports": {
     ".": "./index.js"
   },


### PR DESCRIPTION
Adding `"type": "module"` to form helpers
