### PR TITLE
fix(form-control): dispose of old AbortControllers once validations finish for async validations

### DIFF
--- a/.changeset/spotty-deers-pump.md
+++ b/.changeset/spotty-deers-pump.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/form-control': patch
+---
+
+Dispose of old AbortControllers once validation is complete

--- a/packages/form-control/src/FormControlMixin.ts
+++ b/packages/form-control/src/FormControlMixin.ts
@@ -405,6 +405,9 @@ export function FormControlMixin<
           if (!abortController?.signal.aborted) {
             this.#isValidationPending = false;
             this.#validationCompleteResolver?.();
+            /** Clear old AbortControllers once validation is complete to avoid unnecessary signals */
+            this.#abortController = undefined;
+            this.#previousAbortController = undefined;
           }
         });
 


### PR DESCRIPTION
Clean up old AbortController instances once validations finish
