### PR TITLE
docs(form-helpers): Update for deprecated notice + wording tweak

### DIFF
--- a/packages/form-helpers/README.md
+++ b/packages/form-helpers/README.md
@@ -34,9 +34,9 @@ const form = document.querySelector('#someForm');
 const input = document.querySelector('input');
 
 input.addEventListener( 'keypress', ($event) => {
-  if($event.keyCode === 13) { // Enter key
+  if($event.code === 'Enter') {
     submit(form); // submit event is emitted, and form's submit() method is called if the `submit` event is not `defaultPrevented`
-    console.log(submitted) // submitted will be false if the input doesn't have a value AND is required
+    console.log(submitted) // submitHandler will not be called if the input doesn't have a value AND is required
   }
 });
 


### PR DESCRIPTION
Updated docs because default throws deprecation notice.

![image](https://user-images.githubusercontent.com/472727/217142404-f4c09f52-9ae8-47d6-8aee-2d2e11efccb7.png)
