### PR TITLE
fix(form-control): fix validators, fix incremental validationMessage storage, add tests

### DIFF
--- a/.changeset/sharp-tips-knock.md
+++ b/.changeset/sharp-tips-knock.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/form-control': patch
+---
+
+Fix default minLength and maxLength validator validity keys, fix validationMessage to be iterative (only the first invalid message gets stored)

--- a/packages/form-control/src/FormControlMixin.ts
+++ b/packages/form-control/src/FormControlMixin.ts
@@ -392,7 +392,10 @@ export function FormControlMixin<
             hasChange = true;
           }
 
-          if (!isValid) {
+          // only update the validationMessage for the first invalid scenario
+          // so that earlier invalid validators dont get their messages overwritten by later ones
+          // in the validators array
+          if (!isValid && !validationMessage) {
             validationMessage = this.#getValidatorMessageForValue(validator, value);
           }
         }

--- a/packages/form-control/src/validators.ts
+++ b/packages/form-control/src/validators.ts
@@ -28,7 +28,7 @@ export const programmaticValidator: Validator = {
 
 export const minLengthValidator: Validator = {
   attribute: 'minlength',
-  key: 'rangeUnderflow',
+  key: 'tooShort',
   message(instance: FormControlInterface & { minLength: number }, value: FormValue): string {
     const _value = value as string || '';
     return `Please use at least ${instance.minLength} characters (you are currently using ${_value.length} characters).`;
@@ -49,7 +49,7 @@ export const minLengthValidator: Validator = {
 
 export const maxLengthValidator: Validator = {
   attribute: 'maxlength',
-  key: 'rangeOverflow',
+  key: 'tooLong',
   message(
     instance: FormControlInterface & { maxLength: number },
     value: FormValue

--- a/packages/form-control/tests/validators.test.ts
+++ b/packages/form-control/tests/validators.test.ts
@@ -1,5 +1,4 @@
-import { expect, fixture, fixtureCleanup, html } from '@open-wc/testing';
-import { SinonSpy, spy } from 'sinon';
+import { aTimeout, expect, fixture, fixtureCleanup, html } from '@open-wc/testing';
 import {
   FormControlMixin,
   maxLengthValidator,
@@ -7,6 +6,7 @@ import {
   patternValidator,
   programmaticValidator,
   requiredValidator,
+  validationMessageCallback,
   Validator
 } from '../src';
 
@@ -72,16 +72,16 @@ describe('The FormControlMixin using HTMLElement', () => {
   describe('minLengthValidator', () => {
     it('will not affect the element unless minLength is set', async () => {
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeUnderflow).to.be.false;
+      expect(el.validity.tooShort).to.be.false;
     });
 
     it('will invalidate element when value length is less than minLength', async () => {
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeUnderflow).to.be.false;
+      expect(el.validity.tooShort).to.be.false;
       el.minLength = 3;
       el.value = 'ab';
       expect(el.validity.valid).to.be.false;
-      expect(el.validity.rangeUnderflow).to.be.true;
+      expect(el.validity.tooShort).to.be.true;
       expect(el.internals.validationMessage).to.equal(
         'Please use at least 3 characters (you are currently using 2 characters).'
       );
@@ -89,20 +89,20 @@ describe('The FormControlMixin using HTMLElement', () => {
 
     it('will validate element when value length is equal to minLength', async () => {
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeUnderflow).to.be.false;
+      expect(el.validity.tooShort).to.be.false;
       el.minLength = 3;
       el.value = 'abc';
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeUnderflow).to.be.false;
+      expect(el.validity.tooShort).to.be.false;
     });
 
     it('will validate element when value length is greater than minLength', async () => {
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeUnderflow).to.be.false;
+      expect(el.validity.tooShort).to.be.false;
       el.minLength = 3;
       el.value = 'abcd';
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeUnderflow).to.be.false;
+      expect(el.validity.tooShort).to.be.false;
     });
   });
 
@@ -110,16 +110,16 @@ describe('The FormControlMixin using HTMLElement', () => {
   describe('maxLengthValidator', () => {
     it('will not affect the element unless maxLength is set', async () => {
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeOverflow).to.be.false;
+      expect(el.validity.tooLong).to.be.false;
     });
 
     it('will invalidate controls where value is longer than maxLength', async () => {
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeOverflow).to.be.false;
+      expect(el.validity.tooLong).to.be.false;
       el.maxLength = 3;
       el.value = 'abcd';
       expect(el.validity.valid).to.be.false;
-      expect(el.validity.rangeOverflow).to.be.true;
+      expect(el.validity.tooLong).to.be.true;
       expect(el.internals.validationMessage).to.equal(
         'Please use no more than 3 characters (you are currently using 4 characters).'
       );
@@ -127,32 +127,32 @@ describe('The FormControlMixin using HTMLElement', () => {
 
     it('will validate controls where value is equal to maxLength', async () => {
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeOverflow).to.be.false;
+      expect(el.validity.tooLong).to.be.false;
       el.maxLength = 3;
       el.value = 'abcd';
       expect(el.validity.valid).to.be.false;
-      expect(el.validity.rangeOverflow).to.be.true;
+      expect(el.validity.tooLong).to.be.true;
       expect(el.internals.validationMessage).to.equal(
         'Please use no more than 3 characters (you are currently using 4 characters).'
       );
       el.value = 'abc';
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeOverflow).to.be.false;
+      expect(el.validity.tooLong).to.be.false;
     });
 
     it('will validate controls where value is less than maxLength', async () => {
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeOverflow).to.be.false;
+      expect(el.validity.tooLong).to.be.false;
       el.maxLength = 3;
       el.value = 'abcd';
       expect(el.validity.valid).to.be.false;
-      expect(el.validity.rangeOverflow).to.be.true;
+      expect(el.validity.tooLong).to.be.true;
       expect(el.internals.validationMessage).to.equal(
         'Please use no more than 3 characters (you are currently using 4 characters).'
       );
       el.value = 'ab';
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeOverflow).to.be.false;
+      expect(el.validity.tooLong).to.be.false;
     });
   });
 
@@ -190,16 +190,16 @@ describe('The FormControlMixin using HTMLElement', () => {
   describe('maxLengthValidator', () => {
     it('will not affect the element unless maxLength is set', async () => {
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeOverflow).to.be.false;
+      expect(el.validity.tooLong).to.be.false;
     });
 
     it('will invalidate controls where value is longer than maxLength', async () => {
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeOverflow).to.be.false;
+      expect(el.validity.tooLong).to.be.false;
       el.maxLength = 3;
       el.value = 'abcd';
       expect(el.validity.valid).to.be.false;
-      expect(el.validity.rangeOverflow).to.be.true;
+      expect(el.validity.tooLong).to.be.true;
       expect(el.internals.validationMessage).to.equal(
         'Please use no more than 3 characters (you are currently using 4 characters).'
       );
@@ -207,34 +207,55 @@ describe('The FormControlMixin using HTMLElement', () => {
 
     it('will validate controls where value is equal to maxLength', async () => {
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeOverflow).to.be.false;
+      expect(el.validity.tooLong).to.be.false;
       el.maxLength = 3;
       el.value = 'abcd';
       expect(el.validity.valid).to.be.false;
-      expect(el.validity.rangeOverflow).to.be.true;
+      expect(el.validity.tooLong).to.be.true;
       expect(el.internals.validationMessage).to.equal(
         'Please use no more than 3 characters (you are currently using 4 characters).'
       );
       el.value = 'abc';
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeOverflow).to.be.false;
+      expect(el.validity.tooLong).to.be.false;
     });
 
     it('will validate controls where value is less than maxLength', async () => {
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeOverflow).to.be.false;
+      expect(el.validity.tooLong).to.be.false;
       el.maxLength = 3;
       el.value = 'abcd';
       expect(el.validity.valid).to.be.false;
-      expect(el.validity.rangeOverflow).to.be.true;
+      expect(el.validity.tooLong).to.be.true;
       expect(el.internals.validationMessage).to.equal(
         'Please use no more than 3 characters (you are currently using 4 characters).'
       );
       el.value = 'ab';
       expect(el.validity.valid).to.be.true;
-      expect(el.validity.rangeOverflow).to.be.false;
+      expect(el.validity.tooLong).to.be.false;
     });
   });
+
+  /** iterative validation message */
+  it('should have only the first invalid message when multiple validators are invalid', async () => {
+    el.pattern = '^[A-Z]$';
+    el.maxLength = 5;
+    el.value = 'aBCDEF';
+
+    // expect the error message to be the maxLength validato message because it is the first one
+    // in the array that will return invalid
+    expect(el.validationMessage).to.equal((maxLengthValidator.message as validationMessageCallback)(el, el.value));
+    expect(el.validity.tooLong).to.be.true;
+    expect(el.validity.patternMismatch).to.be.true;
+
+
+    // change the value so that the maxLength validator returns valid
+    el.value = 'aBCDE';
+
+    // expect the error message to be the pattern validator message because it now the first one that will be invalid
+    expect(el.validationMessage).to.equal(patternValidator.message);
+  });
+
 });
 
 export class NativeFormControl extends FormControlMixin(HTMLElement) {}


### PR DESCRIPTION
Fixed the validationMessage issue and added a test for it.

As of this PR, the validationMessage that is set will only ever be the message from the first invalid validator. The validity state will get passed though each loop, but not the message. This will enable messages shown as error messages to be "iterative" while the validity state is always full with multiple errors. This fix also prevents the issue where the last invalid validator message will always overwrite. So folks can "order" their validators in order of importances and ease of correction - for example having the requiredValidator be first and always show that message first if invalid.

Also noticed an error with the existing default validators. The `maxLengthValidator` was set to use the `rangeOverflow` validity key, but the correct key for `maxLength` is `tooLong`. Similar for `minLengthValidator`, the key was set to `rangeUnderflow`, but the correct key is `tooShort`.

The `rangeOverflow` and `rangeUnderflow` validity keys refer to the `min` and `max` properties that deal with numbers. `tooLong` and `tooShort` deal with `minlength` and `maxlength` and strings.