### PR TITLE
feat(form-helpers): the submit helper respects form novalidate

### DIFF
--- a/packages/form-helpers/src/index.ts
+++ b/packages/form-helpers/src/index.ts
@@ -6,7 +6,7 @@
  * @param form {HTMLFormElement} - A form to implicitly submit
  */
 export const submit = (form: HTMLFormElement): void => {
-  if (!form.reportValidity() && !form.noValidate) {
+  if (!form.noValidate && !form.reportValidity()) {
     return;
   } else {
     const submitEvent = new SubmitEvent('submit', {

--- a/packages/form-helpers/src/index.ts
+++ b/packages/form-helpers/src/index.ts
@@ -6,7 +6,7 @@
  * @param form {HTMLFormElement} - A form to implicitly submit
  */
 export const submit = (form: HTMLFormElement): void => {
-  if (!form.reportValidity()) {
+  if (!form.reportValidity() && !form.noValidate) {
     return;
   } else {
     const submitEvent = new SubmitEvent('submit', {

--- a/packages/form-helpers/tests/submit.test.ts
+++ b/packages/form-helpers/tests/submit.test.ts
@@ -70,4 +70,17 @@ describe('The submit form helper', () => {
     form = await fixture<HTMLFormElement>(html`<form @submit="${onSubmit}"></form>`);
     submit(form);
   });
+
+  describe('novalidate', () => {
+    beforeEach(async () => {
+      form = await fixture<HTMLFormElement>(html`<form novalidate @submit="${submitCallback}">
+        <input required>
+      </form>`);
+    });
+
+    it('will respect novalidate attribute', async () => {
+      submit(form);
+      expect(submitted).to.be.true;
+    })
+  })
 });


### PR DESCRIPTION
I added extra check for submit helper to respect `novalidate` attribute of the form element. If `novalidate` present, even form is not valid, submit will happen.

Partially Fixes #39 