### PR TITLE
chore: migrate form control package to use type:module

### DIFF
--- a/.changeset/nine-sheep-itch.md
+++ b/.changeset/nine-sheep-itch.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/form-control': minor
+---
+
+Migrate to a module-type package

--- a/packages/form-control/package.json
+++ b/packages/form-control/package.json
@@ -4,9 +4,11 @@
   "description": "Base class for creating form-participating custom elements",
   "main": "index.js",
   "module": "index.js",
+  "type": "module",
   "exports": {
     ".": "./index.js",
-    "./validators": "./src/validators.js",
+    "./FormControlMixin.js": "./src/FormControlMixin.js",
+    "./validators.js": "./src/validators.js",
     "./types": "./src/types.js"
   },
   "files": [


### PR DESCRIPTION
Migrate the form-control package to type:module. Fixes #42.
