### PR TITLE
feat(form-control): simplify scenario where the validationTarget is not set when the constructor runs

### DIFF
--- a/.changeset/lovely-doors-sleep.md
+++ b/.changeset/lovely-doors-sleep.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/form-control': minor
+---
+
+Fix flow where the validationTarget isn't set when the constructor runs.

--- a/packages/form-control/demo/async-validator-demo.ts
+++ b/packages/form-control/demo/async-validator-demo.ts
@@ -1,4 +1,4 @@
-import { css, LitElement, html, TemplateResult, PropertyValueMap } from 'lit';
+import { css, LitElement, html, TemplateResult, PropertyValues } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { live } from 'lit/directives/live.js';
 import { AsyncValidator, FormControlMixin, FormValue, requiredValidator } from '../src';
@@ -7,12 +7,13 @@ const sleepValidator: AsyncValidator = {
   message: 'Hello world',
   isValid(instance: AsyncValidatorDemo, value: FormValue, signal: AbortSignal): Promise<boolean|void> {
     if (signal.aborted) {
-      return Promise<void>.resolve();
+      return Promise.resolve();
     }
 
     return new Promise((resolve) => {
       const id = setTimeout(() => {
         resolve(value === 'foo');
+        console.log(`Evaluated ${value} for validity update`);
       }, 2000);
 
       signal.addEventListener('abort', () => {
@@ -29,7 +30,7 @@ const onBlurValidator: AsyncValidator = {
   message: 'Length must be a multiple of two',
   isValid(instance: AsyncValidatorDemo, value: string, signal: AbortSignal): Promise<boolean|void> {
     if (signal.aborted) {
-      return Promise<void>.resolve();
+      return Promise.resolve();
     }
 
     return new Promise(resolve => {
@@ -77,7 +78,7 @@ export class AsyncValidatorDemo extends FormControlMixin(LitElement) {
     this.value = event.target.value;
   }
 
-  protected updated(changed: PropertyValueMap<this>): void {
+  protected updated(changed: PropertyValues<this>): void {
     if (changed.has('value')) {
       this.setValue(this.value);
     }

--- a/packages/form-control/src/FormControlMixin.ts
+++ b/packages/form-control/src/FormControlMixin.ts
@@ -93,7 +93,7 @@ export function FormControlMixin<
     #previousAbortController?: AbortController;
 
     /**
-     * Used for trackin if a validation target has been set to manage focus
+     * Used for tracking if a validation target has been set to manage focus
      * when the control's validity is reported
      */
     #awaitingValidationTarget = true;

--- a/packages/form-control/src/FormControlMixin.ts
+++ b/packages/form-control/src/FormControlMixin.ts
@@ -155,6 +155,7 @@ export function FormControlMixin<
           this.validationMessage,
           this.validationTarget
         );
+        this.#awaitingValidationTarget = false;
       }
       this.#touched = true;
       this.#forceError = true;

--- a/packages/form-control/src/FormControlMixin.ts
+++ b/packages/form-control/src/FormControlMixin.ts
@@ -202,9 +202,9 @@ export function FormControlMixin<
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     constructor(...args: any[]) {
       super(...args);
-      this.addEventListener('focus', this.#onFocus);
-      this.addEventListener('blur', this.#onBlur);
-      this.addEventListener('invalid', this.#onInvalid);
+      this.addEventListener?.('focus', this.#onFocus);
+      this.addEventListener?.('blur', this.#onBlur);
+      this.addEventListener?.('invalid', this.#onInvalid);
       this.setValue(null);
     }
 

--- a/packages/form-control/tests/delayedValidationTarget.test.ts
+++ b/packages/form-control/tests/delayedValidationTarget.test.ts
@@ -52,13 +52,6 @@ describe('The FormControlMixin using HTMLElement', () => {
       form.requestSubmit();
       expect(document.activeElement?.shadowRoot?.activeElement).to.be.undefined;
     });
-
-    it('will cancel the validationTarget loop if the control becomes true', async () => {
-      const spy = sinon.spy(window, 'clearInterval');
-      el.internals.setValidity({});
-      await aTimeout(1);
-      expect(spy.called).to.be.true;
-    });
   });
 });
 


### PR DESCRIPTION
I definitely would like this tested, should related to #39
