### PR TITLE
fix(helpers): change submit event type to Event

### DIFF
--- a/.changeset/curly-peas-lick.md
+++ b/.changeset/curly-peas-lick.md
@@ -1,0 +1,5 @@
+---
+'@open-wc/form-helpers': patch
+---
+
+change submit event type to Event for compatibility with jsdom < v21

--- a/packages/form-helpers/src/index.ts
+++ b/packages/form-helpers/src/index.ts
@@ -1,3 +1,12 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+type Constructor<T = Record<string, unknown>> = new (...args: any[]) => T;
+
+/**
+ * Backwards compatibility with jsdom < v21. In jsdom < 21 SubmitEvent is not implemented.
+*/
+const PolyfilledSubmitEvent: Constructor<SubmitEvent> = globalThis.SubmitEvent = typeof globalThis.SubmitEvent !== 'undefined' ? SubmitEvent : Event as unknown as Constructor<SubmitEvent>;
+
+
 /**
  * Implicitly submit a form by first validating all controls. If the form
  * is valid, issue a submit event and if that event is not prevented, manually
@@ -9,7 +18,7 @@ export const submit = (form: HTMLFormElement): void => {
   if (!form.noValidate && !form.reportValidity()) {
     return;
   } else {
-    const submitEvent = new Event('submit', {
+    const submitEvent = new PolyfilledSubmitEvent('submit', {
       bubbles: true,
       cancelable: true
     });

--- a/packages/form-helpers/src/index.ts
+++ b/packages/form-helpers/src/index.ts
@@ -9,7 +9,7 @@ export const submit = (form: HTMLFormElement): void => {
   if (!form.noValidate && !form.reportValidity()) {
     return;
   } else {
-    const submitEvent = new SubmitEvent('submit', {
+    const submitEvent = new Event('submit', {
       bubbles: true,
       cancelable: true
     });

--- a/packages/form-helpers/tests/submit.test.ts
+++ b/packages/form-helpers/tests/submit.test.ts
@@ -63,7 +63,7 @@ describe('The submit form helper', () => {
   });
 
   it('will emit an event that bubbles', async () => {
-    const onSubmit = (event: Event) => {
+    const onSubmit = (event: SubmitEvent) => {
       event.preventDefault();
       expect(event.bubbles).to.be.true;
     }

--- a/packages/form-helpers/tests/submit.test.ts
+++ b/packages/form-helpers/tests/submit.test.ts
@@ -63,7 +63,7 @@ describe('The submit form helper', () => {
   });
 
   it('will emit an event that bubbles', async () => {
-    const onSubmit = (event: SubmitEvent) => {
+    const onSubmit = (event: Event) => {
       event.preventDefault();
       expect(event.bubbles).to.be.true;
     }


### PR DESCRIPTION
changing the submit event type from `SubmitEvent` to just `Event` increases jsdom compatibility to versions less than 21.x

Currently, folks running tests in `jest` with the latest `jest-environment-jsdom` will get `^20.0.0` which doesn't have `SubmitEvent` implemented. Having `SubmitEvent` would force an npm package override to jsdom `^21` which shouldn't really be necessary. IMO when `jest-environment-jsdom` updates we could change back to `SubmitEvent` as a patch bump again.